### PR TITLE
Update Mojito Sinpe plugin to version 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Agrega enlace de pago en la página de pago (opcional), página de gracias y cor
 
 El dueño de la tienda sólo debe agregar su número de teléfono en "Woocommerce > Ajustes > Pagos > SINPE Móvil > Gestionar"
 
+Compatible con WordPress 7.0, WooCommerce 10.8.1, HPOS y WooCommerce Checkout Blocks.
+
 
 ¿Desea colaborar? 
 

--- a/composer.lock
+++ b/composer.lock
@@ -8,29 +8,28 @@
     "packages": [
         {
             "name": "mobiledetect/mobiledetectlib",
-            "version": "4.8.09",
+            "version": "4.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/serbanghita/Mobile-Detect.git",
-                "reference": "a06fe2e546a06bb8c2639d6823d5250b2efb3209"
+                "reference": "ab39168b7556f44c11c80be1222b44b239f5c2e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/serbanghita/Mobile-Detect/zipball/a06fe2e546a06bb8c2639d6823d5250b2efb3209",
-                "reference": "a06fe2e546a06bb8c2639d6823d5250b2efb3209",
+                "url": "https://api.github.com/repos/serbanghita/Mobile-Detect/zipball/ab39168b7556f44c11c80be1222b44b239f5c2e4",
+                "reference": "ab39168b7556f44c11c80be1222b44b239f5c2e4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
-                "psr/cache": "^3.0",
-                "psr/simple-cache": "^3"
+                "php": ">=8.2",
+                "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^v3.65.0",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.12.x-dev",
-                "phpunit/phpunit": "^9.6.18",
-                "squizlabs/php_codesniffer": "^3.11.1"
+                "friendsofphp/php-cs-fixer": "3.95.1",
+                "phpbench/phpbench": "1.6.1",
+                "phpstan/phpstan": "2.1.47",
+                "phpunit/phpunit": "9.6.34",
+                "squizlabs/php_codesniffer": "3.13.5"
             },
             "type": "library",
             "autoload": {
@@ -61,7 +60,7 @@
             ],
             "support": {
                 "issues": "https://github.com/serbanghita/Mobile-Detect/issues",
-                "source": "https://github.com/serbanghita/Mobile-Detect/tree/4.8.09"
+                "source": "https://github.com/serbanghita/Mobile-Detect/tree/4.11.0"
             },
             "funding": [
                 {
@@ -69,7 +68,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-10T15:32:06+00:00"
+            "time": "2026-05-24T12:32:40+00:00"
         },
         {
             "name": "mojitowp/exchange-rate",
@@ -105,16 +104,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "cd6e973e04b4c2b94c86e8612b5a65f0da0e08e7"
-            },
+            "version": "2.2.1",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/cd6e973e04b4c2b94c86e8612b5a65f0da0e08e7",
-                "reference": "cd6e973e04b4c2b94c86e8612b5a65f0da0e08e7",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dea9c8f2d25cc849391042b71e429c1a4bf82660",
+                "reference": "dea9c8f2d25cc849391042b71e429c1a4bf82660",
                 "shasum": ""
             },
             "require": {
@@ -136,6 +130,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -159,56 +164,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-05T16:43:48+00:00"
-        },
-        {
-            "name": "psr/cache",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/cache.git",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for caching libraries",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr-6"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/cache/tree/3.0.0"
-            },
-            "time": "2021-02-03T23:26:27+00:00"
+            "time": "2026-05-28T14:44:12+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -265,26 +221,30 @@
     "packages-dev": [
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.7.1",
+            "version": "v6.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "83448e918bf06d1ed3d67ceb6a985fc266a02fd1"
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/83448e918bf06d1ed3d67ceb6a985fc266a02fd1",
-                "reference": "83448e918bf06d1ed3d67ceb6a985fc266a02fd1",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/90a9412826b9944f93b10bf41d795b5fe68abcd5",
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5",
                 "shasum": ""
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "5.6.1"
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-                "nikic/php-parser": "^4.13",
+                "nikic/php-parser": "^5.5",
                 "php": "^7.4 || ^8.0",
-                "php-stubs/generator": "^0.8.3",
-                "phpdocumentor/reflection-docblock": "^5.4.1",
-                "phpstan/phpstan": "^1.11",
+                "php-stubs/generator": "^0.8.6",
+                "phpdocumentor/reflection-docblock": "^6.0",
+                "phpstan/phpstan": "^2.1",
                 "phpunit/phpunit": "^9.5",
+                "symfony/polyfill-php80": "*",
                 "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
                 "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
             },
@@ -307,22 +267,22 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.7.1"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.4"
             },
-            "time": "2024-11-24T03:57:09+00:00"
+            "time": "2026-05-01T20:36:01+00:00"
         },
         {
             "name": "szepeviktor/phpstan-wordpress",
-            "version": "v2.0.1",
+            "version": "v2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
-                "reference": "f7beb13cd22998e3d913fdb897a1e2553ccd637e"
+                "reference": "aa722f037b2d034828cd6c55ebe9e5c74961927e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/f7beb13cd22998e3d913fdb897a1e2553ccd637e",
-                "reference": "f7beb13cd22998e3d913fdb897a1e2553ccd637e",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/aa722f037b2d034828cd6c55ebe9e5c74961927e",
+                "reference": "aa722f037b2d034828cd6c55ebe9e5c74961927e",
                 "shasum": ""
             },
             "require": {
@@ -332,6 +292,7 @@
             },
             "require-dev": {
                 "composer/composer": "^2.1.14",
+                "composer/semver": "^3.4",
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "php-parallel-lint/php-parallel-lint": "^1.1",
                 "phpstan/phpstan-strict-rules": "^2.0",
@@ -369,9 +330,9 @@
             ],
             "support": {
                 "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
-                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v2.0.1"
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v2.0.3"
             },
-            "time": "2024-12-01T02:13:05+00:00"
+            "time": "2025-09-14T02:58:22+00:00"
         }
     ],
     "aliases": [],
@@ -381,5 +342,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/includes/checkout.js
+++ b/includes/checkout.js
@@ -1,17 +1,233 @@
-const settings = window.wc.wcSettings.getSetting( 'woocommerce_mojito_sinpe_gateway_data', {} );
-const label = window.wp.htmlEntities.decodeEntities( settings.title ) || window.wp.i18n.__( 'Mojito Sinpe', 'mojito-sinpe' );
-const Content = () => {
-    return window.wp.htmlEntities.decodeEntities( settings.description || '' );
-};
-const Block_Gateway = {
-    name: 'mojito-sinpe',
-    label: label,
-    content: Object( window.wp.element.createElement )( Content, null ),
-    edit: Object( window.wp.element.createElement )( Content, null ),
-    canMakePayment: () => true,
-    ariaLabel: label,
-    supports: {
-        features: settings.supports,
-    },
-};
-window.wc.wcBlocksRegistry.registerPaymentMethod( Block_Gateway );
+( function() {
+	'use strict';
+
+	const settings = window.wc.wcSettings.getSetting(
+		'mojito-sinpe_data',
+		window.wc.wcSettings.getSetting( 'woocommerce_mojito_sinpe_gateway_data', {} )
+	);
+
+	const { registerPaymentMethod } = window.wc.wcBlocksRegistry;
+	const { createElement, useEffect, useState } = window.wp.element;
+	const { decodeEntities } = window.wp.htmlEntities;
+	const { __, sprintf } = window.wp.i18n;
+
+	const i18n = settings.i18n || {};
+	const label = decodeEntities( settings.title || __( 'Mojito Sinpe', 'mojito-sinpe' ) );
+	const banks = Array.isArray( settings.banks ) ? settings.banks : [];
+
+	const getBankNumber = ( bankId ) => {
+		const selectedBank = banks.find( ( bank ) => bank.id === bankId );
+
+		return selectedBank && selectedBank.number ? selectedBank.number : '';
+	};
+
+	const getSmsHref = ( bankNumber ) => {
+		const message = settings.message || '';
+
+		return 'sms:+' + encodeURIComponent( bankNumber ) + '?&body=' + encodeURIComponent( message );
+	};
+
+	const getPaymentMethodData = ( bank, voucher ) => ( {
+		mojito_sinpe_bank: bank || '',
+		mojito_sinpe_voucher_id: voucher ? voucher.trim() : '',
+	} );
+
+	const Label = ( props = {} ) => {
+		if ( props.components && props.components.PaymentMethodLabel ) {
+			return createElement( props.components.PaymentMethodLabel, { text: label } );
+		}
+
+		return label;
+	};
+
+	const Content = ( props = {} ) => {
+		const { eventRegistration, emitResponse } = props;
+		const responseTypes = emitResponse && emitResponse.responseTypes
+			? emitResponse.responseTypes
+			: {
+				ERROR: 'error',
+				SUCCESS: 'success',
+			};
+		const [ bank, setBank ] = useState( settings.show_banks_list ? 'none' : '' );
+		const [ voucher, setVoucher ] = useState( '' );
+		const selectedBankNumber = getBankNumber( bank );
+
+		useEffect( () => {
+			if ( ! eventRegistration || ! eventRegistration.onPaymentProcessing ) {
+				return undefined;
+			}
+
+			const unsubscribe = eventRegistration.onPaymentProcessing( async () => {
+				if ( settings.show_banks_list && ! selectedBankNumber ) {
+					return {
+						type: responseTypes.ERROR,
+						message: i18n.bank_required || __( 'Payment error: Please select your bank', 'mojito-sinpe' ),
+					};
+				}
+
+				if ( settings.ask_voucher_id && ! voucher.trim() ) {
+					return {
+						type: responseTypes.ERROR,
+						message: i18n.voucher_required || __( 'Payment error: Please enter your voucher id', 'mojito-sinpe' ),
+					};
+				}
+
+				return {
+					type: responseTypes.SUCCESS,
+					meta: {
+						paymentMethodData: getPaymentMethodData( bank, voucher ),
+					},
+				};
+			} );
+
+			return () => {
+				unsubscribe();
+			};
+		}, [
+			bank,
+			eventRegistration,
+			responseTypes.ERROR,
+			responseTypes.SUCCESS,
+			selectedBankNumber,
+			voucher,
+		] );
+
+		const children = [];
+		const description = decodeEntities( settings.description || '' );
+
+		if ( description ) {
+			children.push(
+				createElement(
+					'p',
+					{
+						className: 'mojito-sinpe-block-description',
+						key: 'description',
+					},
+					description
+				)
+			);
+		}
+
+		if ( settings.show_banks_list ) {
+			children.push(
+				createElement(
+					'p',
+					{
+						className: 'mojito-sinpe-block-bank-field',
+						key: 'bank',
+					},
+					createElement(
+						'label',
+						{
+							htmlFor: 'mojito_sinpe_bank_block',
+						},
+						i18n.select_bank || __( 'Select your bank', 'mojito-sinpe' )
+					),
+					createElement(
+						'select',
+						{
+							id: 'mojito_sinpe_bank_block',
+							className: 'mojito_sinpe_bank_selector',
+							value: bank,
+							onChange: ( event ) => setBank( event.target.value ),
+						},
+						banks.map( ( option ) => createElement(
+							'option',
+							{
+								key: option.id,
+								value: option.id,
+							},
+							decodeEntities( option.label || '' )
+						) )
+					)
+				)
+			);
+		}
+
+		if ( ! settings.show_in_checkout ) {
+			children.push(
+				createElement(
+					'p',
+					{
+						className: 'mojito-sinpe-block-email-note',
+						key: 'email-note',
+					},
+					i18n.receive_link_in_email || __( 'You will receive the SINPE Payment link in the order confirmation email. Open it on your mobile.', 'mojito-sinpe' )
+				)
+			);
+		} else if ( settings.show_text_after_banks_list === 'yes' && selectedBankNumber ) {
+			const message = settings.message || '';
+
+			children.push(
+				createElement(
+					'p',
+					{
+						className: 'mojito-sinpe-block-payment-instructions',
+						key: 'instructions',
+					},
+					settings.is_mobile
+						? createElement(
+							'a',
+							{
+								className: 'mojito-sinpe-block-link',
+								href: getSmsHref( selectedBankNumber ),
+							},
+							sprintf( i18n.pay_now || __( 'Pay now: %s', 'mojito-sinpe' ), settings.amount || '' )
+						)
+						: sprintf( i18n.send_sms || __( 'Send a SMS to %s with the content: %s', 'mojito-sinpe' ), selectedBankNumber, message )
+				)
+			);
+		}
+
+		if ( settings.ask_voucher_id ) {
+			children.push(
+				createElement(
+					'p',
+					{
+						className: 'mojito-sinpe-block-voucher-field',
+						key: 'voucher',
+					},
+					createElement(
+						'label',
+						{
+							htmlFor: 'mojito_sinpe_voucher_id_block',
+						},
+						i18n.voucher_label || __( 'Enter your voucher ID', 'mojito-sinpe' )
+					),
+					createElement(
+						'input',
+						{
+							id: 'mojito_sinpe_voucher_id_block',
+							className: 'mojito_sinpe_voucher_id',
+							type: 'text',
+							required: true,
+							value: voucher,
+							placeholder: i18n.voucher_placeholder || __( 'Enter your voucher ID here', 'mojito-sinpe' ),
+							onChange: ( event ) => setVoucher( event.target.value ),
+						}
+					)
+				)
+			);
+		}
+
+		return createElement(
+			'div',
+			{
+				className: 'mojito-sinpe-block',
+			},
+			children
+		);
+	};
+
+	registerPaymentMethod( {
+		name: 'mojito-sinpe',
+		label: createElement( Label, null ),
+		content: createElement( Content, null ),
+		edit: createElement( Content, null ),
+		canMakePayment: () => !! settings.enabled,
+		ariaLabel: label,
+		supports: {
+			features: settings.supports || [ 'products' ],
+		},
+	} );
+}() );

--- a/includes/class-mojito-compatibility-product-vendors.php
+++ b/includes/class-mojito-compatibility-product-vendors.php
@@ -115,16 +115,17 @@ class Mojito_Sinpe_Compatibility_Product_Vendors_Support {
 	/**
 	 * Save term fields.
 	 *
-	 * @param string $term_id Term.
+	 * @param int|string $term_id Term.
 	 */
 	public function save_vendor_custom_fields( $term_id ) {
 
-		if ( ! wp_verify_nonce( $_POST['vendor_custom_sinpe_nonce'], basename( __FILE__ ) ) ) {
+		if ( empty( $_POST['vendor_custom_sinpe_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['vendor_custom_sinpe_nonce'] ) ), basename( __FILE__ ) ) ) {
 			return;
 		}
 
+		$term_id   = (int) $term_id;
 		$old_sinpe = get_term_meta( $term_id, 'sinpe-number', true );
-		$new_sinpe = sanitize_text_field( $_POST['sinpe-number'] );
+		$new_sinpe = isset( $_POST['sinpe-number'] ) ? sanitize_text_field( wp_unslash( $_POST['sinpe-number'] ) ) : '';
 
 		if ( ! empty( $old_sinpe ) && '' === $new_sinpe ) {
 			delete_term_meta( $term_id, 'sinpe-number' );

--- a/includes/class-mojito-sinpe-gateway-block.php
+++ b/includes/class-mojito-sinpe-gateway-block.php
@@ -117,7 +117,8 @@ class Mojito_Sinpe_Gateway_Block extends AbstractPaymentMethodType {
 		}
 
 		$payment_data = isset( $context->payment_data ) && is_array( $context->payment_data ) ? $context->payment_data : array();
-		$processed    = $this->gateway->process_sinpe_order( $context->order, $payment_data );
+		// Store API owns cart emptying and redirects; this shared path persists SINPE meta, note, and status.
+		$processed = $this->gateway->process_sinpe_order( $context->order, $payment_data );
 
 		if ( is_wp_error( $processed ) ) {
 			throw new \Exception( $processed->get_error_message() );

--- a/includes/class-mojito-sinpe-gateway-block.php
+++ b/includes/class-mojito-sinpe-gateway-block.php
@@ -1,57 +1,134 @@
 <?php
 /**
- * WooCommerce
+ * WooCommerce Blocks integration.
  *
  * @link       https://mojitowp.com/
  * @since      1.1.1
-  *
+ *
  * @package    Mojito_Sinpe
  * @subpackage Mojito_Sinpe/public
  * @author     Mojito Team <support@mojitowp.com>
  */
 
 namespace Mojito_Sinpe;
-use \Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
+
+use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
 
 /**
- * Mojito Sinpe Gateway Block
+ * Mojito Sinpe Gateway Block.
  */
-class Mojito_Sinpe_Gateway_Block extends AbstractPaymentMethodType 
-{
-    private $gateway;
-    protected $name = 'mojito-sinpe';
+class Mojito_Sinpe_Gateway_Block extends AbstractPaymentMethodType {
 
-    public function initialize() {
-        $this->settings = get_option( 'woocommerce_mojito_sinpe_gateway_settings', [] );
-        $this->gateway = new Mojito_Sinpe_Gateway();
-    }
-    public function is_active() {
-        return $this->gateway->is_available();
-    }
-    public function get_payment_method_script_handles() {
-        wp_register_script(
-            'moji-sinpe-checkout-js',
-            plugin_dir_url(__FILE__) . 'checkout.js',
-            [
-                'wc-blocks-registry',
-                'wc-settings',
-                'wp-element',
-                'wp-html-entities',
-                'wp-i18n',
-            ],
-            null,
-            true
-        );
-		return [ 'moji-sinpe-checkout-js' ];
+	/**
+	 * Gateway instance.
+	 *
+	 * @var Mojito_Sinpe_Gateway|null
+	 */
+	private $gateway = null;
 
+	/**
+	 * Payment method name.
+	 *
+	 * @var string
+	 */
+	protected $name = Mojito_Sinpe_Gateway::ID;
 
-    }
-    public function get_payment_method_data() {
-        return [
-			'title'       => $this->get_setting( 'title' ),
-			'description' => $this->get_setting( 'description' ),
-			'supports'    => $this->get_supported_features(),
-		];
-    }
+	/**
+	 * Initialize the payment method.
+	 *
+	 * @return void
+	 */
+	public function initialize() {
+		$this->settings = get_option( 'woocommerce_mojito_sinpe_gateway_settings', array() );
+		$this->gateway  = new Mojito_Sinpe_Gateway();
 
+		add_action( 'woocommerce_rest_checkout_process_payment_with_context', array( $this, 'process_payment_with_context' ), 10, 2 );
+	}
+
+	/**
+	 * Check if the payment method is active.
+	 *
+	 * @return bool
+	 */
+	public function is_active() {
+		return $this->gateway instanceof Mojito_Sinpe_Gateway && $this->gateway->is_available();
+	}
+
+	/**
+	 * Register block checkout scripts.
+	 *
+	 * @return array<int,string>
+	 */
+	public function get_payment_method_script_handles() {
+		wp_register_script(
+			'mojito-sinpe-checkout-blocks',
+			plugin_dir_url( __FILE__ ) . 'checkout.js',
+			array(
+				'wc-blocks-registry',
+				'wc-settings',
+				'wp-element',
+				'wp-html-entities',
+				'wp-i18n',
+			),
+			defined( 'MOJITO_SINPE_VERSION' ) ? MOJITO_SINPE_VERSION : null,
+			true
+		);
+
+		return array( 'mojito-sinpe-checkout-blocks' );
+	}
+
+	/**
+	 * Load the same script in the block editor.
+	 *
+	 * @return array<int,string>
+	 */
+	public function get_payment_method_script_handles_for_admin() {
+		return $this->get_payment_method_script_handles();
+	}
+
+	/**
+	 * Data made available to the checkout block script.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function get_payment_method_data() {
+		if ( ! $this->gateway instanceof Mojito_Sinpe_Gateway ) {
+			$this->gateway = new Mojito_Sinpe_Gateway();
+		}
+
+		return $this->gateway->get_blocks_payment_data();
+	}
+
+	/**
+	 * Process block checkout payment data through the Store API hook.
+	 *
+	 * @param object $context Payment context.
+	 * @param object $result Payment result.
+	 * @throws \Exception When SINPE validation fails.
+	 * @return void
+	 */
+	public function process_payment_with_context( $context, $result ) {
+		if ( ! isset( $context->payment_method ) || Mojito_Sinpe_Gateway::ID !== $context->payment_method ) {
+			return;
+		}
+
+		if ( ! $this->gateway instanceof Mojito_Sinpe_Gateway ) {
+			$this->gateway = new Mojito_Sinpe_Gateway();
+		}
+
+		$payment_data = isset( $context->payment_data ) && is_array( $context->payment_data ) ? $context->payment_data : array();
+		$processed    = $this->gateway->process_sinpe_order( $context->order, $payment_data );
+
+		if ( is_wp_error( $processed ) ) {
+			throw new \Exception( $processed->get_error_message() );
+		}
+
+		if ( method_exists( $result, 'set_status' ) ) {
+			$result->set_status( 'success' );
+		}
+
+		if ( method_exists( $result, 'set_redirect_url' ) ) {
+			$result->set_redirect_url( $this->gateway->get_return_url( $context->order ) );
+		}
+	}
 }

--- a/includes/class-mojito-sinpe-gateway.php
+++ b/includes/class-mojito-sinpe-gateway.php
@@ -506,7 +506,7 @@ class Mojito_Sinpe_Gateway extends WC_Payment_Gateway {
 	}
 
 	public function is_available(): bool {
-		return parent::is_available() && '' !== $this->get_store_owner_number();
+		return (bool) parent::is_available() && '' !== $this->get_store_owner_number();
 	}
 
 	/**

--- a/includes/class-mojito-sinpe-gateway.php
+++ b/includes/class-mojito-sinpe-gateway.php
@@ -4,7 +4,6 @@
  *
  * @link       https://mojitowp.com/
  * @since      1.0.0
- * WooCommerce compatibility of the plugin.
  *
  * @package    Mojito_Sinpe
  * @subpackage Mojito_Sinpe/public
@@ -13,13 +12,15 @@
 
 namespace Mojito_Sinpe;
 
-use WC_Payment_Gateway;
 use Detection\MobileDetect;
+use WC_Payment_Gateway;
 
 /**
  * Mojito Sinpe Gateway
  */
 class Mojito_Sinpe_Gateway extends WC_Payment_Gateway {
+
+	const ID = 'mojito-sinpe';
 
 	public $instructions;
 
@@ -31,8 +32,9 @@ class Mojito_Sinpe_Gateway extends WC_Payment_Gateway {
 	 */
 	public function __construct() {
 
-		$this->id                 = 'mojito-sinpe';
+		$this->id                 = self::ID;
 		$this->has_fields         = true;
+		$this->supports           = array( 'products' );
 		$this->method_title       = __( 'SINPE Móvil', 'mojito-sinpe' );
 		$this->method_description = __( 'Payment using SINPE Móvil', 'mojito-sinpe' );
 
@@ -40,46 +42,21 @@ class Mojito_Sinpe_Gateway extends WC_Payment_Gateway {
 		$this->init_form_fields();
 		$this->init_settings();
 
-		/**
-		 * Update option
-		 */
-		if ( ! empty( $this->settings['enable-mojito-sinpe-debug'] ) ) {
-			$current_debug = get_option( 'mojito_sinpe_debug' );
-			$setting_debug = $this->settings['enable-mojito-sinpe-debug'];
-			if ( $current_debug !== $setting_debug ) {
-				update_option( 'mojito_sinpe_debug', $setting_debug );
-			}
-		}
+		$this->sync_debug_setting();
+		$this->set_gateway_icon();
 
-		$icon = 'sinpe-movil';
-		if ( 'no-logo' === $this->settings['sinpe-logo-size'] ) {
-			$icon = false;
-		} elseif ( '500x275' === $this->settings['sinpe-logo-size'] ) {
-			$icon = 'sinpe-movil-500x275';
-		} elseif ( '400x220' === $this->settings['sinpe-logo-size'] ) {
-			$icon = 'sinpe-movil-400x220';
-		} elseif ( '300x165' === $this->settings['sinpe-logo-size'] ) {
-			$icon = 'sinpe-movil-300x165';
-		} elseif ( '200x110' === $this->settings['sinpe-logo-size'] ) {
-			$icon = 'sinpe-movil-200x110';
-		} elseif ( '100x55' === $this->settings['sinpe-logo-size'] ) {
-			$icon = 'sinpe-movil-100x55';
-		} elseif ( '50x28' === $this->settings['sinpe-logo-size'] ) {
-			$icon = 'sinpe-movil-50x28';
-		} else {
-			$icon = 'sinpe-movil';
-		}
-
-		if ( false !== $icon ) {
-			$this->icon = plugin_dir_url( __DIR__ ) . 'public/img/' . $icon . '.png';
-		}
-
+		$this->enabled      = $this->get_option( 'enabled' );
 		$this->title        = $this->get_option( 'title' );
-		$this->description  = $this->get_option( 'description' ) ;
+		$this->description  = $this->get_option( 'description' );
 		$this->instructions = $this->get_option( 'instructions' );
 
 		// Actions.
-		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
+		add_action(
+			'woocommerce_update_options_payment_gateways_' . $this->id,
+			function() {
+				$this->process_admin_options();
+			}
+		);
 		add_action( 'woocommerce_thankyou_mojito-sinpe', array( $this, 'thankyou_page' ) );
 
 		// Customer Emails.
@@ -91,7 +68,6 @@ class Mojito_Sinpe_Gateway extends WC_Payment_Gateway {
 		if ( isset( $_SESSION['mojito-sinpe-email-instructions-already-added'] ) ) {
 			unset( $_SESSION['mojito-sinpe-email-instructions-already-added'] );
 		}
-
 	}
 
 	/**
@@ -200,7 +176,7 @@ class Mojito_Sinpe_Gateway extends WC_Payment_Gateway {
 				'default' => 'hacienda',
 				'options' => array(
 					'hacienda' => __( 'Ministerio de Hacienda', 'mojito-sinpe' ),
-					'custom' => __( 'Custom', 'mojito-sinpe' ),
+					'custom'   => __( 'Custom', 'mojito-sinpe' ),
 				),
 			),
 			'exchange-rate-custom' => array(
@@ -218,7 +194,118 @@ class Mojito_Sinpe_Gateway extends WC_Payment_Gateway {
 	}
 
 	/**
-	 * Show options for SINPE in the checkout page
+	 * Get the configured SINPE bank labels.
+	 *
+	 * @return array<string,string>
+	 */
+	public static function get_banks() {
+		$sinpe_banks = array(
+			'none'            => __( 'Select your bank', 'mojito-sinpe' ),
+			'bn'              => 'Banco Nacional de Costa Rica',
+			'bcr'             => 'Banco de Costa Rica',
+			'bac'             => 'Banco BAC San José',
+			'bct'             => 'Banco BCT',
+			'caja-de-ande'    => 'Caja de Ande',
+			'coopealianza'    => 'Coopealianza',
+			'coopecaja'       => 'Coopecaja',
+			'coopelecheros'   => 'Coopelecheros',
+			'coocique'        => 'Coocique',
+			'credecoop'       => 'Credecoop',
+			'davivienda'      => 'Banco Davivienda',
+			'lafise'          => 'Banco Lafise',
+			'mucap'           => 'MUCAP',
+			'mutual-alajuela' => 'Grupo Mutual Alajuela - La Vivienda',
+			'promerica'       => 'Banco Promerica',
+		);
+
+		return apply_filters( 'mojito_sinpe_banks_numbers', $sinpe_banks );
+	}
+
+	/**
+	 * Get the SINPE phone number per bank.
+	 *
+	 * @return array<string,string>
+	 */
+	public static function get_bank_phone_numbers() {
+		$bank_phone_numbers = array(
+			'bn'              => '2627',
+			'bcr'             => '4066',
+			'bac'             => '70701222',
+			'bct'             => '60400300',
+			'caja-de-ande'    => '62229532',
+			'coopealianza'    => '62229523',
+			'coopecaja'       => '62229526',
+			'coopelecheros'   => '60405957',
+			'coocique'        => '46002905',
+			'credecoop'       => '71984256',
+			'davivienda'      => '70707474',
+			'lafise'          => '9091',
+			'mucap'           => '62229525',
+			'mutual-alajuela' => '60575079',
+			'promerica'       => '62232450',
+		);
+
+		return apply_filters( 'mojito_sinpe_bank_phone_numbers', $bank_phone_numbers );
+	}
+
+	/**
+	 * Get a bank SINPE phone number.
+	 *
+	 * @param string $bank Bank key.
+	 * @return string
+	 */
+	public static function get_bank_phone_number( $bank ) {
+		$bank_phone_numbers = self::get_bank_phone_numbers();
+
+		return isset( $bank_phone_numbers[ $bank ] ) ? $bank_phone_numbers[ $bank ] : '';
+	}
+
+	/**
+	 * Get settings/data used by the checkout block script.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function get_blocks_payment_data() {
+		$amount = $this->get_checkout_amount();
+		$banks  = array();
+
+		foreach ( self::get_banks() as $bank_key => $bank_label ) {
+			$banks[] = array(
+				'id'     => $bank_key,
+				'label'  => $bank_label,
+				'number' => self::get_bank_phone_number( $bank_key ),
+			);
+		}
+
+		return array(
+			'title'                      => $this->title,
+			'description'                => $this->description,
+			'supports'                   => $this->supports,
+			'enabled'                    => $this->is_available(),
+			'amount'                     => $amount,
+			'message'                    => $this->get_payment_message( $amount ),
+			'store_sinpe_number'         => $this->get_store_owner_number(),
+			'is_mobile'                  => $this->is_mobile(),
+			'show_in_checkout'           => $this->should_show_link_in_checkout(),
+			'show_banks_list'            => $this->should_show_banks_list(),
+			'ask_voucher_id'             => $this->should_ask_voucher_id(),
+			'show_text_after_banks_list' => apply_filters( 'mojito_sinpe_show_text_after_banks_list', 'yes' ),
+			'banks'                      => $banks,
+			'i18n'                       => array(
+				'select_bank'           => __( 'Select your bank', 'mojito-sinpe' ),
+				'bank_required'         => __( 'Payment error: Please select your bank', 'mojito-sinpe' ),
+				'voucher_label'         => __( 'Enter your voucher ID', 'mojito-sinpe' ),
+				'voucher_placeholder'   => apply_filters( 'mojito_sinpe_ask_voucher_placeholder', __( 'Enter your voucher ID here', 'mojito-sinpe' ) ),
+				'voucher_required'      => __( 'Payment error: Please enter your voucher id', 'mojito-sinpe' ),
+				'receive_link_in_email' => __( 'You will receive the SINPE Payment link in the order confirmation email. Open it on your mobile.', 'mojito-sinpe' ),
+				'pay_now'               => __( 'Pay now: %s', 'mojito-sinpe' ),
+				'send_sms'              => __( 'Send a SMS to %s with the content: %s', 'mojito-sinpe' ),
+			),
+		);
+	}
+
+	/**
+	 * Show options for SINPE in the checkout page.
 	 *
 	 * @return void
 	 */
@@ -228,7 +315,7 @@ class Mojito_Sinpe_Gateway extends WC_Payment_Gateway {
 			return;
 		}
 
-		$number = $this->settings['number'];
+		$number = $this->get_store_owner_number();
 
 		if ( empty( $number ) ) {
 			mojito_sinpe_debug( 'Phone number is empty' );
@@ -237,46 +324,15 @@ class Mojito_Sinpe_Gateway extends WC_Payment_Gateway {
 
 		$description = $this->get_description();
 		if ( $description ) {
-			echo wpautop( wptexturize( $description ) );
+			echo wp_kses_post( wpautop( wptexturize( $description ) ) );
 		}
 
-		/*
-		Note: Web Archive URL. The real url was removed from Central Bank's SINPE official documentation.
-		URL: https://web.archive.org/web/20210824000600/https://www.bccr.fi.cr/sistema-de-pagos/informaci%C3%B3n-general/tarifas-y-comisiones-del-sinpe/comisiones-cobradas-por-las-entidades-financieras/sinpe-m%C3%B3vil
-
-		2021-12-27
-		https://www.bccr.fi.cr/sistema-de-pagos/tarifas-y-comisiones-del-sinpe/comisiones-cobradas-por-las-entidades-financieras/sinpe-m%c3%b3vil
-		https://www.bccr.fi.cr/sistema-de-pagos/DocTarifas/SinpeMovil-Web.xlsx
-
-		*/
-		$sinpe_banks = array(
-			'none'            => __( 'Select your bank', 'mojito-sinpe' ),
-			'bn'              => 'Banco Nacional de Costa Rica', // 2627
-			'bcr'             => 'Banco de Costa Rica', // 4066
-			'bac'             => 'Banco BAC San José', // 7070-1222
-			'bct'             => 'Banco BCT', // 6040-0300
-			'caja-de-ande'    => 'Caja de Ande', // 6222-9532
-			'coopealianza'    => 'Coopealianza', // 6222-9523
-			'coopecaja'       => 'Coopecaja', // 6222-9526
-			'coopelecheros'   => 'Coopelecheros', // 6040-5957
-			'coocique'        => 'Coocique', // 4600-2905
-			'credecoop'       => 'Credecoop', // 7198-4256
-			'davivienda'      => 'Banco Davivienda', // 7070-7474
-			'lafise'          => 'Banco Lafise', // 9091
-			'mucap'           => 'MUCAP', // 6222-9525
-			'mutual-alajuela' => 'Grupo Mutual Alajuela - La Vivienda', // 6057-5079
-			'promerica'       => 'Banco Promerica', // 6223-2450
-		);
-
-		$sinpe_banks = apply_filters( 'mojito_sinpe_banks_numbers', $sinpe_banks );
-
-		if ( 'yes' === $this->settings['show-banks-list-in-checkout'] ) {
-
+		if ( $this->should_show_banks_list() ) {
 			?>
 			<p>
-				<label for="mojito_sinpe_bank"><?php echo __( 'Select your bank', 'mojito-sinpe' ); ?></label>
+				<label for="mojito_sinpe_bank"><?php echo esc_html__( 'Select your bank', 'mojito-sinpe' ); ?></label>
 				<select class="mojito_sinpe_bank_selector" id="mojito_sinpe_bank" name="mojito_sinpe_bank">
-					<?php foreach ( $sinpe_banks as $option_key => $option_value ) : ?>
+					<?php foreach ( self::get_banks() as $option_key => $option_value ) : ?>
 						<option value="<?php echo esc_attr( $option_key ); ?>"><?php echo esc_html( $option_value ); ?></option>
 					<?php endforeach; ?>
 				</select>
@@ -284,108 +340,64 @@ class Mojito_Sinpe_Gateway extends WC_Payment_Gateway {
 			<?php
 		}
 
-		if ( 'yes' !== $this->settings['show-in-checkout'] ) {
-			echo __( 'You will receive the SINPE Payment link in the order confirmation email. Open it on your mobile.', 'mojito-sinpe' );
+		if ( ! $this->should_show_link_in_checkout() ) {
+			echo esc_html__( 'You will receive the SINPE Payment link in the order confirmation email. Open it on your mobile.', 'mojito-sinpe' );
 			return;
 		}
 
-		global $woocommerce;
+		$amount  = $this->get_checkout_amount();
+		$message = $this->get_payment_message( $amount );
+		$type    = $this->is_mobile() ? 'mobile' : 'desktop';
 
-		$amount  = $woocommerce->cart->total;
+		printf(
+			'<a href="#" data-type="%1$s" data-msj="%2$s" data-amount="%3$s" data-number="%4$s" class="mojito-sinpe-link">%5$s</a>',
+			esc_attr( $type ),
+			esc_attr( $message ),
+			esc_attr( (string) $amount ),
+			esc_attr( $number ),
+			esc_html( sprintf( __( 'Pay now: %s', 'mojito-sinpe' ), $amount ) )
+		);
 
-		/**
-		 * Exchange rate
-		 */
-		$exchange_rate        = 1;
-		$exchange_rate_enable = $this->settings['exchange-rate-enable'];
-		$exchange_rate_origin = $this->settings['exchange-rate-origin'];
-		$exchange_rate_custom = $this->settings['exchange-rate-custom'];
-
-		if ( 'yes' === $exchange_rate_enable ) {
-
-			switch ( $exchange_rate_origin ) {
-				case 'hacienda':
-					$rates = \Mojito\ExchangeRate\Factory::create( \Mojito\ExchangeRate\ProviderTypes::CR_Hacienda );
-					$rate  = $rates->getRates();
-					if ( isset($rate->dolar->venta->valor)) {
-						$exchange_rate = $rate->dolar->venta->valor;
-					} else {
-						$exchange_rate = 1;
-					}
-					break;
-				case 'custom':
-					if ( is_numeric( $exchange_rate_custom ) ) {
-						$exchange_rate = $exchange_rate_custom;
-					}
-					break;
-			}
-
-			/**
-			 * Filter the exchange rate
-			 */
-			$exchange_rate = apply_filters( 'mojito_sinpe_exchange_rate', $exchange_rate );
-
-			/**
-			 * Si el exchange rate está activo, quiere decir que la tienda vende en dólares
-			 * Entonces se multiplica el monto por el exchange rate para obtener la cantidad en colones
-			 */
-			$amount = $amount * $exchange_rate;
-			$amount = round( $amount, 0 );
-			if ( $amount < 1 ) {
-				$amount = $amount * -1;
-			}
-		}
-
-		$amount = apply_filters( 'mojito_sinpe_amount', $amount );
-
-		$message = 'Pase ' . $amount . ' ' . $number;
-
-		if ( $this->is_mobile() ) {
-			echo '<a data-type="mobile" data-msj="' . $message . '" data-amount="' . $amount . '" data-number="' . $number . '" class="mojito-sinpe-link">' . sprintf( __( 'Pay now: %s', 'mojito-sinpe' ), $amount ) . '</a>';
-		} else {
-			echo '<a data-type="desktop" data-msj="' . $message . '" data-amount="' . $amount . '" data-number="' . $number . '" class="mojito-sinpe-link">' . sprintf( __( 'Pay now: %s', 'mojito-sinpe' ), $amount ) . '</a>';
+		if ( 'desktop' === $type ) {
 			echo '<p class="mojito-sinpe-payment-container"></p>';
 		}
 
-		if ( 'yes' === $this->settings['ask-voucher-id'] && 'yes' === $this->settings['show-banks-list-in-checkout'] ) {
-
+		if ( $this->should_ask_voucher_id() ) {
 			$placeholder = apply_filters( 'mojito_sinpe_ask_voucher_placeholder', __( 'Enter your voucher ID here', 'mojito-sinpe' ) );
-		?>
+			?>
 			<p>
-				<label for="mojito_sinpe_voucher_id"><?php echo __( 'Enter your voucher ID', 'mojito-sinpe' ); ?></label>
-				<input required class="mojito_sinpe_voucher_id" id="mojito_sinpe_voucher_id" name="mojito_sinpe_voucher_id" type="text" placeholder="<?php echo $placeholder; ?>">
+				<label for="mojito_sinpe_voucher_id"><?php echo esc_html__( 'Enter your voucher ID', 'mojito-sinpe' ); ?></label>
+				<input required class="mojito_sinpe_voucher_id" id="mojito_sinpe_voucher_id" name="mojito_sinpe_voucher_id" type="text" placeholder="<?php echo esc_attr( $placeholder ); ?>">
 			</p>
-		<?php
+			<?php
 		}
 
 		do_action( 'mojito_sinpe_after_fields' );
-		
 	}
 
 	/**
-	 * Detect mobile client
+	 * Detect mobile client.
 	 *
 	 * @return boolean
 	 */
 	public function is_mobile() {
 
-		if ( ! class_exists( 'MobileDetect' ) ) {
+		if ( ! class_exists( 'Detection\MobileDetect' ) ) {
 			return false;
 		}
 
 		$detect = new MobileDetect();
 
-		$is_mobile = false;
+		try {
+			if ( $detect->isMobile() ) {
+				return true;
+			}
 
-		if ( method_exists( 'Mobile_Detect', 'isMobile' ) ) {
-			$is_mobile = $detect->isMobile();
+			return $detect->isTablet();
+		} catch ( \Exception $exception ) {
+			mojito_sinpe_debug( $exception->getMessage() );
+			return false;
 		}
-
-		if ( false === $is_mobile && method_exists( 'Mobile_Detect', 'isTablet' ) ) {
-			$is_mobile = $detect->isTablet();
-		}
-
-		return $is_mobile;
 	}
 
 
@@ -407,14 +419,14 @@ class Mojito_Sinpe_Gateway extends WC_Payment_Gateway {
 	/**
 	 * Add content to the WC emails.
 	 *
-	 * @param WC_Order $order Order object.
-	 * @param bool     $sent_to_admin Sent to admin.
-	 * @param bool     $plain_text Email format: plain text or HTML.
+	 * @param \WC_Order $order Order object.
+	 * @param bool      $sent_to_admin Sent to admin.
+	 * @param bool      $plain_text Email format: plain text or HTML.
 	 */
 	public function email_instructions( $order, $sent_to_admin, $plain_text = false ) {
 
 		if ( empty( $_SESSION['mojito-sinpe-email-instructions-already-added'] ) ) {
-			if ( ! $sent_to_admin && 'mojito-sinpe' === $order->get_payment_method() && $order->has_status( 'on-hold' ) ) {
+			if ( ! $sent_to_admin && self::ID === $order->get_payment_method() && $order->has_status( 'on-hold' ) ) {
 				if ( $this->instructions ) {
 					echo wp_kses_post( wpautop( wptexturize( $this->instructions ) ) . PHP_EOL );
 					$_SESSION['mojito-sinpe-email-instructions-already-added'] = 1;
@@ -428,49 +440,246 @@ class Mojito_Sinpe_Gateway extends WC_Payment_Gateway {
 	 * Process the payment and return the result.
 	 *
 	 * @param int $order_id Order ID.
-	 * @return array
+	 * @return array<string,string>
 	 */
 	public function process_payment( $order_id ) {
 
-		global $woocommerce;
-
-		$bank = sanitize_text_field( $_POST['mojito_sinpe_bank'] );
-
-		if ( 'yes' === $this->settings['show-banks-list-in-checkout'] ) {
-			if ( empty( $bank ) || 'none' === $bank ) {
-				wc_add_notice( __( 'Payment error: Please select your bank', 'mojito-sinpe' ), 'error' );
-				return;
-			}
+		$order = wc_get_order( $order_id );
+		if ( ! $order instanceof \WC_Order ) {
+			wc_add_notice( __( 'Not a valid order', 'mojito-sinpe' ), 'error' );
+			return array( 'result' => 'failure' );
 		}
 
-		$order = new \WC_Order( $order_id );
+		$payment_data = array(
+			'mojito_sinpe_bank'       => isset( $_POST['mojito_sinpe_bank'] ) ? sanitize_text_field( wp_unslash( $_POST['mojito_sinpe_bank'] ) ) : '',
+			'mojito_sinpe_voucher_id' => isset( $_POST['mojito_sinpe_voucher_id'] ) ? sanitize_text_field( wp_unslash( $_POST['mojito_sinpe_voucher_id'] ) ) : '',
+		);
 
-		if ( 'yes' === $this->settings['ask-voucher-id'] && 'yes' === $this->settings['show-banks-list-in-checkout'] ) {
-
-			$voucher = sanitize_text_field( $_POST['mojito_sinpe_voucher_id'] );
-
-			if ( empty( $voucher ) ) {
-				wc_add_notice( __( 'Payment error: Please enter your voucher id', 'mojito-sinpe' ), 'error' );
-				return;
-			}
-
-			$order->add_order_note( sprintf( __( 'SINPE Voucher id: %s' , 'mojito-sinpe' ), $voucher ) );
+		$result = $this->process_sinpe_order( $order, $payment_data );
+		if ( is_wp_error( $result ) ) {
+			wc_add_notice( $result->get_error_message(), 'error' );
+			return array( 'result' => 'failure' );
 		}
 
-		// Mark as on-hold ( we're awaiting the SINPE).
-		$order->update_status( 'on-hold', __( 'Awaiting SINPE payment', 'mojito-sinpe' ) );
+		if ( function_exists( 'WC' ) && WC()->cart ) {
+			WC()->cart->empty_cart();
+		}
 
-		// Remove cart.
-		$woocommerce->cart->empty_cart();
-
-		// Return thankyou redirect.
 		return array(
 			'result'   => 'success',
 			'redirect' => $this->get_return_url( $order ),
 		);
 	}
-	public function is_available() {
-        // Lógica para determinar si está disponible. Por defecto, siempre disponible.
-        return parent::is_available();
-    }
+
+	/**
+	 * Shared order processing for classic checkout and Store API checkout.
+	 *
+	 * @param mixed               $order Order object.
+	 * @param array<string,mixed> $payment_data Payment data.
+	 * @return true|\WP_Error
+	 */
+	public function process_sinpe_order( $order, array $payment_data ) {
+		if ( ! $order instanceof \WC_Order ) {
+			return new \WP_Error( 'mojito_sinpe_invalid_order', __( 'Not a valid order', 'mojito-sinpe' ) );
+		}
+
+		$bank    = isset( $payment_data['mojito_sinpe_bank'] ) ? sanitize_text_field( $payment_data['mojito_sinpe_bank'] ) : '';
+		$voucher = isset( $payment_data['mojito_sinpe_voucher_id'] ) ? sanitize_text_field( $payment_data['mojito_sinpe_voucher_id'] ) : '';
+
+		$validation = $this->validate_payment_data( $bank, $voucher );
+		if ( is_wp_error( $validation ) ) {
+			return $validation;
+		}
+
+		if ( $this->should_show_banks_list() ) {
+			$order->update_meta_data( 'mojito_sinpe_bank', $bank );
+		}
+
+		if ( $this->should_ask_voucher_id() ) {
+			$order->add_order_note( sprintf( __( 'SINPE Voucher id: %s', 'mojito-sinpe' ), $voucher ) );
+		}
+
+		$order->update_status( 'on-hold', __( 'Awaiting SINPE payment', 'mojito-sinpe' ) );
+		$order->save();
+
+		return true;
+	}
+
+	public function is_available(): bool {
+		return parent::is_available() && '' !== $this->get_store_owner_number();
+	}
+
+	/**
+	 * Validate checkout payment data.
+	 *
+	 * @param string $bank Selected bank.
+	 * @param string $voucher Voucher id.
+	 * @return true|\WP_Error
+	 */
+	private function validate_payment_data( $bank, $voucher ) {
+		if ( $this->should_show_banks_list() && ( empty( $bank ) || 'none' === $bank || '' === self::get_bank_phone_number( $bank ) ) ) {
+			return new \WP_Error( 'mojito_sinpe_bank_required', __( 'Payment error: Please select your bank', 'mojito-sinpe' ) );
+		}
+
+		if ( $this->should_ask_voucher_id() && empty( $voucher ) ) {
+			return new \WP_Error( 'mojito_sinpe_voucher_required', __( 'Payment error: Please enter your voucher id', 'mojito-sinpe' ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get a setting safely.
+	 *
+	 * @param string $key Setting key.
+	 * @param mixed  $default Default value.
+	 * @return mixed
+	 */
+	private function get_setting_value( $key, $default = '' ) {
+		return isset( $this->settings[ $key ] ) ? $this->settings[ $key ] : $default;
+	}
+
+	/**
+	 * Synchronize debug option with gateway settings.
+	 *
+	 * @return void
+	 */
+	private function sync_debug_setting() {
+		$setting_debug = $this->get_setting_value( 'enable-mojito-sinpe-debug', 'no' );
+		$current_debug = get_option( 'mojito_sinpe_debug' );
+
+		if ( $current_debug !== $setting_debug ) {
+			update_option( 'mojito_sinpe_debug', $setting_debug );
+		}
+	}
+
+	/**
+	 * Set the gateway icon URL.
+	 *
+	 * @return void
+	 */
+	private function set_gateway_icon() {
+		$icon_map = array(
+			'500x275' => 'sinpe-movil',
+			'400x220' => 'sinpe-movil-400x220',
+			'300x165' => 'sinpe-movil-300x165',
+			'200x110' => 'sinpe-movil-200x110',
+			'100x55'  => 'sinpe-movil-100x55',
+			'50x28'   => 'sinpe-movil-50x28',
+		);
+
+		$icon_size = $this->get_setting_value( 'sinpe-logo-size', 'no-logo' );
+		if ( 'no-logo' === $icon_size ) {
+			return;
+		}
+
+		$icon = isset( $icon_map[ $icon_size ] ) ? $icon_map[ $icon_size ] : 'sinpe-movil';
+
+		$this->icon = plugin_dir_url( __DIR__ ) . 'public/img/' . $icon . '.png';
+	}
+
+	/**
+	 * Check if the checkout bank list should be shown.
+	 *
+	 * @return bool
+	 */
+	private function should_show_banks_list() {
+		return 'yes' === $this->get_setting_value( 'show-banks-list-in-checkout', 'yes' );
+	}
+
+	/**
+	 * Check if the checkout payment link should be shown.
+	 *
+	 * @return bool
+	 */
+	private function should_show_link_in_checkout() {
+		return 'yes' === $this->get_setting_value( 'show-in-checkout', 'yes' );
+	}
+
+	/**
+	 * Check if voucher id should be requested.
+	 *
+	 * @return bool
+	 */
+	private function should_ask_voucher_id() {
+		return 'yes' === $this->get_setting_value( 'ask-voucher-id', 'no' ) && $this->should_show_banks_list();
+	}
+
+	/**
+	 * Get store owner SINPE number.
+	 *
+	 * @return string
+	 */
+	private function get_store_owner_number() {
+		return trim( (string) $this->get_setting_value( 'number', '' ) );
+	}
+
+	/**
+	 * Get checkout amount transformed by exchange-rate options and filters.
+	 *
+	 * @return float|int
+	 */
+	private function get_checkout_amount() {
+		$amount = 0;
+
+		if ( function_exists( 'WC' ) && WC()->cart ) {
+			$amount = WC()->cart->total;
+		}
+
+		return $this->calculate_sinpe_amount( $amount );
+	}
+
+	/**
+	 * Calculate the amount to include in SINPE instructions.
+	 *
+	 * @param float|int|string $amount Amount in store currency.
+	 * @return float|int
+	 */
+	private function calculate_sinpe_amount( $amount ) {
+		$amount = is_numeric( $amount ) ? (float) $amount : 0;
+
+		if ( 'yes' === $this->get_setting_value( 'exchange-rate-enable', 'yes' ) ) {
+			$exchange_rate        = 1;
+			$exchange_rate_origin = $this->get_setting_value( 'exchange-rate-origin', 'hacienda' );
+			$exchange_rate_custom = $this->get_setting_value( 'exchange-rate-custom', '' );
+
+			switch ( $exchange_rate_origin ) {
+				case 'hacienda':
+					$rates = \Mojito\ExchangeRate\Factory::create( \Mojito\ExchangeRate\ProviderTypes::CR_Hacienda );
+					$rate  = $rates->getRates();
+					if ( isset( $rate->dolar->venta->valor ) ) {
+						$exchange_rate = $rate->dolar->venta->valor;
+					}
+					break;
+				case 'custom':
+					if ( is_numeric( $exchange_rate_custom ) ) {
+						$exchange_rate = (float) $exchange_rate_custom;
+					}
+					break;
+			}
+
+			$exchange_rate = apply_filters( 'mojito_sinpe_exchange_rate', $exchange_rate );
+			$amount        = round( $amount * (float) $exchange_rate, 0 );
+		}
+
+		if ( $amount < 0 ) {
+			$amount *= -1;
+		}
+
+		return apply_filters( 'mojito_sinpe_amount', $amount );
+	}
+
+	/**
+	 * Get SINPE SMS message.
+	 *
+	 * @param float|int|null $amount Amount.
+	 * @return string
+	 */
+	private function get_payment_message( $amount = null ) {
+		if ( null === $amount ) {
+			$amount = $this->get_checkout_amount();
+		}
+
+		return sprintf( 'Pase %s %s', $amount, $this->get_store_owner_number() );
+	}
 }

--- a/includes/class-mojito-sinpe.php
+++ b/includes/class-mojito-sinpe.php
@@ -140,7 +140,7 @@ class Mojito_Sinpe {
 						array(
 							'methods'             => 'GET',
 							'callback'            => array( $this, 'payment_link' ),
-							'permission_callback' => '__return_true',
+							'permission_callback' => array( $this, 'can_open_payment_link' ),
 						)
 					);
 				}
@@ -180,6 +180,32 @@ class Mojito_Sinpe {
 	}
 
 	/**
+	 * Validate access to the public SINPE payment link.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return bool|\WP_Error
+	 */
+	public function can_open_payment_link( $request ) {
+		$order_id  = absint( $request->get_param( 'order' ) );
+		$order_key = sanitize_text_field( (string) $request->get_param( 'key' ) );
+
+		if ( ! $order_id || empty( $order_key ) ) {
+			return new \WP_Error( 'mojito_sinpe_invalid_payment_link', __( 'Not a valid order', 'mojito-sinpe' ), array( 'status' => 403 ) );
+		}
+
+		$order = wc_get_order( $order_id );
+		if ( ! $order instanceof \WC_Order ) {
+			return new \WP_Error( 'mojito_sinpe_invalid_payment_link', __( 'Not a valid order', 'mojito-sinpe' ), array( 'status' => 403 ) );
+		}
+
+		if ( ! hash_equals( $order->get_order_key(), $order_key ) ) {
+			return new \WP_Error( 'mojito_sinpe_invalid_payment_link', __( 'Not a valid order', 'mojito-sinpe' ), array( 'status' => 403 ) );
+		}
+
+		return true;
+	}
+
+	/**
 	 * Open Payment link from confirmation order
 	 */
 	public function payment_link( $request = null ) {
@@ -197,8 +223,10 @@ class Mojito_Sinpe {
 		 */
 		if ( $request instanceof \WP_REST_Request ) {
 			$order_id = absint( $request->get_param( 'order' ) );
+			$key      = sanitize_text_field( (string) $request->get_param( 'key' ) );
 		} else {
 			$order_id = isset( $_GET['order'] ) ? absint( wp_unslash( $_GET['order'] ) ) : 0;
+			$key      = isset( $_GET['key'] ) ? sanitize_text_field( wp_unslash( $_GET['key'] ) ) : '';
 		}
 
 		/**
@@ -217,6 +245,10 @@ class Mojito_Sinpe {
 		 * Is a valid order?
 		 */
 		if ( ! $order instanceof \WC_Order ) {
+			return __( 'Not a valid order', 'mojito-sinpe' );
+		}
+
+		if ( empty( $key ) || ! hash_equals( $order->get_order_key(), $key ) ) {
 			return __( 'Not a valid order', 'mojito-sinpe' );
 		}
 
@@ -359,7 +391,7 @@ class Mojito_Sinpe {
 		/**
 		 * The link address to website to prevent double payments. Also gmail blocks "sms" in href attribute.
 		 */
-		$link = add_query_arg( 'order', $order->get_id(), rest_url( 'mojito-sinpe/v1/open-payment-link/' ) );
+		$link = $this->get_payment_link_url( $order );
 
 		printf(
 			'<p>%1$s <a href="%2$s">%3$s</a></p><br><br>',
@@ -436,7 +468,7 @@ class Mojito_Sinpe {
 			/**
 			 * The link address to website to prevent double payments. Also gmail blocks "sms" in href attribute.
 			 */
-			$link = add_query_arg( 'order', $order->get_id(), rest_url( 'mojito-sinpe/v1/open-payment-link/' ) );
+			$link = $this->get_payment_link_url( $order );
 
 			printf(
 				' <a href="%1$s">%2$s</a><br><br>',
@@ -472,6 +504,22 @@ class Mojito_Sinpe {
 
 		return Mojito_Sinpe_Gateway::get_bank_phone_number( $order->get_meta( 'mojito_sinpe_bank', true ) );
 
+	}
+
+	/**
+	 * Build the signed REST URL that opens the SINPE SMS app.
+	 *
+	 * @param \WC_Order $order Order object.
+	 * @return string
+	 */
+	private function get_payment_link_url( $order ) {
+		return add_query_arg(
+			array(
+				'order' => $order->get_id(),
+				'key'   => $order->get_order_key(),
+			),
+			rest_url( 'mojito-sinpe/v1/open-payment-link/' )
+		);
 	}
 
 	/**

--- a/includes/class-mojito-sinpe.php
+++ b/includes/class-mojito-sinpe.php
@@ -15,7 +15,6 @@
 namespace Mojito_Sinpe;
 
 use Detection\MobileDetect;
-use \Automattic\WooCommerce\Blocks\Assets\Api as WooCommerce_Blocks_Assets_Api;
 
 /**
  * The core plugin class.
@@ -78,7 +77,7 @@ class Mojito_Sinpe {
 		if ( defined( 'MOJITO_SINPE_VERSION' ) ) {
 			$this->version = MOJITO_SINPE_VERSION;
 		} else {
-			$this->version = '1.2.0';
+			$this->version = '1.3.0';
 		}
 		$this->plugin_name = 'mojito-sinpe';
 		$this->mojito_sinpe_settings = array();
@@ -86,10 +85,13 @@ class Mojito_Sinpe {
 		/**
 		 * Define plugin name as constant.
 		 */
-		define( 'MOJITO_SINPE_SLUG', $this->plugin_name );
+		if ( ! defined( 'MOJITO_SINPE_SLUG' ) ) {
+			define( 'MOJITO_SINPE_SLUG', $this->plugin_name );
+		}
 
 		$this->load_dependencies();
 		$this->set_locale();
+		// @phpstan-ignore-next-line Empty extension point kept for plugin-boilerplate compatibility.
 		$this->define_admin_hooks();
 		$this->define_public_hooks();
 
@@ -107,14 +109,7 @@ class Mojito_Sinpe {
 		add_action(
 			'plugins_loaded',
 			function () {
-				if (!class_exists('WC_Payment_Gateway')) {
-					return;
-				}
-				/**
-				 * The class responsible for defining all actions that occur in the public-facing
-				 * side of the site.
-				 */
-				require_once MOJITO_SINPE_DIR . 'includes/class-mojito-sinpe-gateway.php';
+				$this->load_gateway_class();
 			}
 		);
 
@@ -138,61 +133,56 @@ class Mojito_Sinpe {
 		 */
 		add_action(
 			'rest_api_init',
-			function () {
-				register_rest_route(
-					'mojito-sinpe/v1',
-					'/open-payment-link/',
-					array(
-						'methods'  => 'GET',
-						'callback' => array( $this, 'payment_link' ),
-						'permission_callback' => array(),
-					)
-				);
-			}
+				function () {
+					register_rest_route(
+						'mojito-sinpe/v1',
+						'/open-payment-link/',
+						array(
+							'methods'             => 'GET',
+							'callback'            => array( $this, 'payment_link' ),
+							'permission_callback' => '__return_true',
+						)
+					);
+				}
 		);
 
 		add_action(
 			'woocommerce_init',
-			function(){
+			function() {
 				add_filter( 'woocommerce_available_payment_gateways', function( $available_gateways ) {
-					if ( ! empty( $available_gateways['mojito-sinpe'] ) ) {
-						$this->mojito_sinpe_settings = $available_gateways['mojito-sinpe']->settings;
+					if ( ! empty( $available_gateways[ Mojito_Sinpe_Gateway::ID ] ) ) {
+						$this->mojito_sinpe_settings = $available_gateways[ Mojito_Sinpe_Gateway::ID ]->settings;
 					}
 					return $available_gateways;
 				});
 			}
 		);
 
-		// Hook the custom function to the 'woocommerce_blocks_loaded' action
-		/* Working on it, not ready yet
-		add_action( 'woocommerce_blocks_loaded', function(){
+		add_action( 'woocommerce_blocks_loaded', function() {
+			if ( ! $this->load_gateway_class() ) {
+				return;
+			}
 
-			// Check if the required class exists
 			if ( ! class_exists( 'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) ) {
 				return;
 			}
 
-
-			// Include the custom Blocks Checkout class
 			require_once MOJITO_SINPE_DIR . 'includes/class-mojito-sinpe-gateway-block.php';
 
-			// Hook the registration function to the 'woocommerce_blocks_payment_method_type_registration' action
 			add_action(
 				'woocommerce_blocks_payment_method_type_registration',
 				function( \Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry ) {
-					// Register an instance of My_Custom_Gateway_Blocks
 					$payment_method_registry->register( new Mojito_Sinpe_Gateway_Block() );
 				}
 			);
 		} );
-		*/
 
 	}
 
 	/**
 	 * Open Payment link from confirmation order
 	 */
-	public function payment_link() {
+	public function payment_link( $request = null ) {
 
 		/**
 		 * Work only in mobile
@@ -205,31 +195,35 @@ class Mojito_Sinpe {
 		/**
 		 * Get order id
 		 */
-		$order_id = sanitize_text_field( $_GET['order'] );
+		if ( $request instanceof \WP_REST_Request ) {
+			$order_id = absint( $request->get_param( 'order' ) );
+		} else {
+			$order_id = isset( $_GET['order'] ) ? absint( wp_unslash( $_GET['order'] ) ) : 0;
+		}
 
 		/**
 		 * Check order id
 		 */
-		if ( ! is_numeric( $order_id ) ) {
+		if ( ! $order_id ) {
 			return __( 'Not a valid order', 'mojito-sinpe' );
 		}
 
 		/**
 		 * Load Order data
 		 */
-		$order    = wc_get_order( $order_id );
+		$order = wc_get_order( $order_id );
 
 		/**
 		 * Is a valid order?
 		 */
-		if ( is_bool( $order ) ) {
+		if ( ! $order instanceof \WC_Order ) {
 			return __( 'Not a valid order', 'mojito-sinpe' );
 		}
 
 		/**
 		 * Check if is the correct payment method
 		 */
-		if ( 'mojito-sinpe' !== $order->get_payment_method() ) {
+		if ( Mojito_Sinpe_Gateway::ID !== $order->get_payment_method() ) {
 			return __( 'This order hasn\'t SINPE Móvil as payment method', 'mojito-sinpe' );
 		}
 
@@ -269,11 +263,15 @@ class Mojito_Sinpe {
 		$concat = '?';
 		$detect = new MobileDetect();
 
-		if ( true === $detect->isIphone() ) {
-			$concat = '&';
+		try {
+			if ( true === $detect->is( 'iPhone' ) ) {
+				$concat = '&';
+			}
+		} catch ( \Exception $exception ) {
+			mojito_sinpe_debug( $exception->getMessage() );
 		}
 
-		wp_redirect( 'sms:+' . $bank_number . $concat . 'body=' . $message, 301 );
+		wp_redirect( esc_url_raw( 'sms:+' . rawurlencode( $bank_number ) . $concat . 'body=' . rawurlencode( $message ), array( 'sms' ) ), 302 );
 
 		exit;
 	}
@@ -285,7 +283,11 @@ class Mojito_Sinpe {
 	public function save_client_bank_selection( $order_id ) {
 
 		if ( ! empty( $_POST['mojito_sinpe_bank'] ) ) {
-			update_post_meta( $order_id, 'mojito_sinpe_bank', sanitize_text_field( $_POST['mojito_sinpe_bank'] ) );
+			$order = wc_get_order( $order_id );
+			if ( $order instanceof \WC_Order ) {
+				$order->update_meta_data( 'mojito_sinpe_bank', sanitize_text_field( wp_unslash( $_POST['mojito_sinpe_bank'] ) ) );
+				$order->save();
+			}
 		}
 	}
 
@@ -295,7 +297,9 @@ class Mojito_Sinpe {
 	 */
 	public function add_sinpe_link_to_order_email( $order, $sent_to_admin, $plain_text, $email ) {
 
-		if ( 'yes' !== $this->mojito_sinpe_settings['show-in-email'] ) {
+		$settings = $this->get_mojito_sinpe_settings();
+
+		if ( 'yes' !== $settings['show-in-email'] ) {
 			return;
 		}
 
@@ -316,7 +320,7 @@ class Mojito_Sinpe {
 		/**
 		 * Check if is the correct payment method
 		 */
-		if ( 'mojito-sinpe' !== $order->get_payment_method() ) {
+		if ( Mojito_Sinpe_Gateway::ID !== $order->get_payment_method() ) {
 			return;
 		}
 
@@ -347,20 +351,22 @@ class Mojito_Sinpe {
 		$total   = round( $order->get_total(), 0);
 		$message = sprintf( __( 'Pase %s %s', 'mojito-sinpe' ), $total, $store_sinpe_number );
 
-		echo '<p>' . sprintf( __( 'Send a SMS to %s with the content: %s', 'mojito-sinpe' ), $bank_number, $message );
-		echo '<p>' . __( 'Are you on mobile? ', 'mojito-sinpe' );
+		printf(
+			'<p>%s</p>',
+			esc_html( sprintf( __( 'Send a SMS to %s with the content: %s', 'mojito-sinpe' ), $bank_number, $message ) )
+		);
 
 		/**
 		 * The link address to website to prevent double payments. Also gmail blocks "sms" in href attribute.
 		 */
-		$link  = '<a href="';
-		$link .= rest_url() . 'mojito-sinpe/v1/open-payment-link?order=' . $order->get_id();
-		$link .= '">';
-		$link .= apply_filters( 'mojito_sinpe_email_label', __( 'Pay here SINPE Móvil', 'mojito-sinpe' ) );
-		$link .= '</a>';
-		$link .= '<br><br>';
+		$link = add_query_arg( 'order', $order->get_id(), rest_url( 'mojito-sinpe/v1/open-payment-link/' ) );
 
-		echo $link;
+		printf(
+			'<p>%1$s <a href="%2$s">%3$s</a></p><br><br>',
+			esc_html__( 'Are you on mobile? ', 'mojito-sinpe' ),
+			esc_url( $link ),
+			esc_html( apply_filters( 'mojito_sinpe_email_label', __( 'Pay here SINPE Móvil', 'mojito-sinpe' ) ) )
+		);
 
 	}
 
@@ -369,22 +375,24 @@ class Mojito_Sinpe {
 	 */
 	public function add_sinpe_link_to_thankyou_page( $order_id ) {
 
-		if ( is_ajax() ) {
+		if ( wp_doing_ajax() ) {
 			return;
 		}
 
-		if ( !isset( $this->mojito_sinpe_settings['show-in-thankyou-page'] ) ) {
-			return;
-		}
+		$settings = $this->get_mojito_sinpe_settings();
 
-		if ( 'yes' !== $this->mojito_sinpe_settings['show-in-thankyou-page'] ) {
+		if ( 'yes' !== $settings['show-in-thankyou-page'] ) {
 			return;
 		}
 
 		/**
 		 * Load Order data
 		 */
-		$order    = wc_get_order( $order_id );
+		$order = wc_get_order( $order_id );
+
+		if ( ! $order instanceof \WC_Order ) {
+			return;
+		}
 
 		/**
 		 * Check if order is paid
@@ -397,7 +405,7 @@ class Mojito_Sinpe {
 		/**
 		 * Check if there is bank number
 		 */
-		if (empty($bank_number)) {
+		if ( empty( $bank_number ) ) {
 			return;
 		}
 
@@ -412,7 +420,10 @@ class Mojito_Sinpe {
 		$total   = round( $order->get_total(), 0 );
 		$message = sprintf( __( 'Pase %s %s', 'mojito-sinpe' ), $total, $store_sinpe_number );
 
-		echo '<p>' . sprintf( __( 'Send a SMS to %s with the content: %s', 'mojito-sinpe' ), $bank_number, $message );
+		printf(
+			'<p>%s</p>',
+			esc_html( sprintf( __( 'Send a SMS to %s with the content: %s', 'mojito-sinpe' ), $bank_number, $message ) )
+		);
 
 		/**
 		 * If mobile, show the link
@@ -420,20 +431,18 @@ class Mojito_Sinpe {
 		$sinpe_gateway = new Mojito_Sinpe_Gateway();
 		if ( $sinpe_gateway->is_mobile() ) {
 
-			echo '<p>' . __( 'Are you on mobile?', 'mojito-sinpe' );
+			echo '<p>' . esc_html__( 'Are you on mobile?', 'mojito-sinpe' );
 
 			/**
 			 * The link address to website to prevent double payments. Also gmail blocks "sms" in href attribute.
 			 */
-			$link = '<a href="';
-			$link .= rest_url() . 'mojito-sinpe/v1/open-payment-link?order=' . $order->get_id();
-			$link .= '">';
-			$link .= ' '; // Yes, this space is Ok.
-			$link .= apply_filters( 'mojito_sinpe_email_label', __( 'Pay here SINPE Móvil', 'mojito-sinpe' ) );
-			$link .= '</a>';
-			$link .= '<br><br>';
+			$link = add_query_arg( 'order', $order->get_id(), rest_url( 'mojito-sinpe/v1/open-payment-link/' ) );
 
-			echo $link;
+			printf(
+				' <a href="%1$s">%2$s</a><br><br>',
+				esc_url( $link ),
+				esc_html( apply_filters( 'mojito_sinpe_email_label', __( 'Pay here SINPE Móvil', 'mojito-sinpe' ) ) )
+			);
 		}
 		
 	}
@@ -444,7 +453,9 @@ class Mojito_Sinpe {
 	 * @return string
 	 */
 	private function get_store_owner_bank_number() {
-		return $this->mojito_sinpe_settings['number'];
+		$settings = $this->get_mojito_sinpe_settings();
+
+		return isset( $settings['number'] ) ? $settings['number'] : '';
 	}
 
 	/**
@@ -454,82 +465,51 @@ class Mojito_Sinpe {
 	 */
 	private function get_bank_number( $order_id ) {
 
-		/**
-		 * Get Bank selected by client
-		 */
-		$bank = get_post_meta( $order_id, 'mojito_sinpe_bank', true );
-
-		/**
-		 * Set the bank number
-		 */
-		$bank_number = '';
-
-		switch ( $bank ) {
-
-			case 'bn':
-				$bank_number = '2627';
-				break;
-
-			case 'bcr':
-				$bank_number = '4066';
-				break;
-
-			case 'bac':
-				$bank_number = '70701222';
-				break;
-
-			case 'bct':
-				$bank_number = '60400300';
-				break;
-
-			case 'caja-de-ande':
-				$bank_number = '62229532';
-				break;
-
-			case 'coopealianza':
-				$bank_number = '62229523';
-				break;
-
-			case 'coopecaja':
-				$bank_number = '62229526';
-				break;
-
-			case 'coopelecheros':
-				$bank_number = '60405957';
-				break;
-
-			case 'coocique':
-				$bank_number = '46002905';
-				break;
-
-			case 'credecoop':
-				$bank_number = '71984256';
-				break;
-
-			case 'davivienda':
-				$bank_number = '70707474';
-				break;
-
-			case 'lafise':
-				$bank_number = '9091';
-				break;
-
-			case 'mucap':
-				$bank_number = '62229525';
-				break;
-
-			case 'mutual-alajuela':
-				$bank_number = '60575079';
-				break;
-
-			case 'promerica':
-				$bank_number = '62232450';
-				break;
+		$order = wc_get_order( $order_id );
+		if ( ! $order instanceof \WC_Order ) {
+			return '';
 		}
 
-		return $bank_number;
+		return Mojito_Sinpe_Gateway::get_bank_phone_number( $order->get_meta( 'mojito_sinpe_bank', true ) );
 
 	}
+
+	/**
+	 * Get gateway settings with safe defaults.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function get_mojito_sinpe_settings() {
+		$defaults = array(
+			'number'                => '',
+			'show-in-email'         => 'yes',
+			'show-in-thankyou-page' => 'yes',
+		);
+
+		if ( empty( $this->mojito_sinpe_settings ) ) {
+			$this->mojito_sinpe_settings = get_option( 'woocommerce_mojito_sinpe_gateway_settings', array() );
+		}
+
+		return wp_parse_args( $this->mojito_sinpe_settings, $defaults );
+	}
+
+	/**
+	 * Load the WooCommerce payment gateway class when WooCommerce is ready.
+	 *
+	 * @return bool
+	 */
+	private function load_gateway_class() {
+		if ( ! class_exists( 'WC_Payment_Gateway' ) ) {
+			return false;
+		}
+
+		if ( ! class_exists( __NAMESPACE__ . '\Mojito_Sinpe_Gateway' ) ) {
+			require_once MOJITO_SINPE_DIR . 'includes/class-mojito-sinpe-gateway.php';
+		}
+
+		return true;
+	}
+
 	/**
 	 * Load the required dependencies for this plugin.
 	 *

--- a/languages/mojito-sinpe.pot
+++ b/languages/mojito-sinpe.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Mojito Sinpe 1.2.0\n"
+"Project-Id-Version: Mojito Sinpe 1.3.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/mojito-sinpe\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/mojito-sinpe.php
+++ b/mojito-sinpe.php
@@ -10,8 +10,9 @@
  * Plugin Name: Mojito Sinpe
  * Plugin URI: https://mojitowp.com/
  * Description: Sinpe Móvil as Woocommerce gateway
- * Version: 1.2.0
- * Requires at least: 5.2
+ * Version: 1.3.0
+ * Requires at least: 7.0
+ * Tested up to: 7.0
  * Requires PHP: 8.1
  * Author: Mojito Team
  * Author URI: https://mojitowp.com/
@@ -19,8 +20,8 @@
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: mojito-sinpe
  * Domain Path: /languages
- * WC requires at least: 8.2.0
- * WC tested up to: 9.5.2
+ * WC requires at least: 10.8
+ * WC tested up to: 10.8.1
  */
 
 namespace Mojito_Sinpe;
@@ -48,7 +49,7 @@ if ( ! function_exists( 'mojito_sinpe_debug' ) ) {
 			return;
 		}
 		
-		error_log( print_r( $message, 1 ) );
+		error_log( print_r( $message, true ) );
 
 		if ( class_exists( 'WC_Logger' ) ) {
 			$logger = new \WC_Logger();
@@ -60,7 +61,7 @@ if ( ! function_exists( 'mojito_sinpe_debug' ) ) {
 /**
  * Version.
  */
-define( 'MOJITO_SINPE_VERSION', '1.2.0' );
+define( 'MOJITO_SINPE_VERSION', '1.3.0' );
 
 /**
  * Define plugin constants.
@@ -76,6 +77,7 @@ register_activation_hook(
 	__FILE__,
 	function () {
 		require_once MOJITO_SINPE_DIR . 'includes/class-mojito-sinpe-activator.php';
+		// @phpstan-ignore-next-line Empty extension point kept for activation compatibility.
 		Mojito_Sinpe_Activator::activate();
 	}
 );
@@ -87,6 +89,7 @@ register_deactivation_hook(
 	__FILE__,
 	function () {
 		require_once MOJITO_SINPE_DIR . 'includes/class-mojito-sinpe-deactivator.php';
+		// @phpstan-ignore-next-line Empty extension point kept for deactivation compatibility.
 		Mojito_Sinpe_Deactivator::deactivate();
 	}
 );
@@ -132,15 +135,15 @@ if ( $load ) {
 	/**
 	 * Compatibility with WooCommerce declarations
 	 */
-	add_action('before_woocommerce_init', function(){
+	add_action( 'before_woocommerce_init', function() {
 		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
 			// Declare compatibility for WooCommerce HPOS (High-Performance Order Storage)
 			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
 			
 			// Declare compatibility for 'cart_checkout_blocks'
-			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('cart_checkout_blocks', __FILE__, true);
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'cart_checkout_blocks', __FILE__, true );
 		}
-	});
+	} );
 
 	mojito_sinpe_run();
 }

--- a/phpstan-stubs/woocommerce-stubs.php
+++ b/phpstan-stubs/woocommerce-stubs.php
@@ -18,6 +18,7 @@ namespace {
 
 	class WC_Order {
 		public function get_id(): int {}
+		public function get_order_key(): string {}
 		public function get_payment_method(): string {}
 		public function has_status( string $status ): bool {}
 		public function is_paid(): bool {}

--- a/phpstan-stubs/woocommerce-stubs.php
+++ b/phpstan-stubs/woocommerce-stubs.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace {
+	define( 'MOJITO_SINPE_DIR', '' );
+	define( 'WC_PRODUCT_VENDORS_TAXONOMY', 'wcpv_product_vendors' );
+
+	class WC_Cart {
+		/** @var float|int|string */
+		public $total = 0;
+
+		public function empty_cart(): void {}
+	}
+
+	class WC_Global {
+		/** @var WC_Cart|null */
+		public $cart;
+	}
+
+	class WC_Order {
+		public function get_id(): int {}
+		public function get_payment_method(): string {}
+		public function has_status( string $status ): bool {}
+		public function is_paid(): bool {}
+		/** @return float|int|string */
+		public function get_total() {}
+		public function update_meta_data( string $key, $value ): void {}
+		public function get_meta( string $key, bool $single = true ) {}
+		public function add_order_note( string $note ): void {}
+		public function update_status( string $new_status, string $note = '' ): void {}
+		public function save(): void {}
+	}
+
+	class WC_Payment_Gateway {
+		/** @var string */
+		public $id = '';
+		/** @var bool */
+		public $has_fields = false;
+		/** @var array<int,string> */
+		public $supports = array();
+		/** @var string */
+		public $method_title = '';
+		/** @var string */
+		public $method_description = '';
+		/** @var array<string,mixed> */
+		public $settings = array();
+		/** @var array<string,mixed> */
+		public $form_fields = array();
+		/** @var string */
+		public $enabled = 'yes';
+		/** @var string */
+		public $icon = '';
+		/** @var string */
+		public $title = '';
+		/** @var string */
+		public $description = '';
+
+		public function init_settings(): void {}
+		public function get_option( string $key, $empty_value = null ) {}
+		public function get_description(): string {}
+		public function process_admin_options(): bool {}
+		public function get_return_url( WC_Order $order ): string {}
+		public function is_available(): bool {}
+	}
+
+	function WC(): WC_Global {}
+
+	/** @return WC_Order|false */
+	function wc_get_order( $order_id ) {}
+
+	function wc_add_notice( string $message, string $notice_type = 'success' ): void {}
+
+	function is_checkout(): bool {}
+}
+
+namespace Automattic\WooCommerce\Blocks\Payments\Integrations {
+	abstract class AbstractPaymentMethodType {
+		/** @var array<string,mixed> */
+		protected $settings = array();
+		/** @var string */
+		protected $name = '';
+
+		public function get_setting( string $name, $default = null ) {}
+		/** @return array<int,string> */
+		public function get_supported_features(): array {}
+	}
+}
+
+namespace Automattic\WooCommerce\Blocks\Payments {
+	class PaymentMethodRegistry {
+		public function register( $payment_method_type ): void {}
+	}
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,8 +3,13 @@ includes:
 parameters:
 	bootstrapFiles:
 		- vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
+		- phpstan-stubs/woocommerce-stubs.php
 	level: 5
 	paths:
-		- .
+		- admin
+		- includes
+		- languages
+		- mojito-sinpe.php
+		- public
 	excludePaths:
 		- vendor/

--- a/public/class-mojito-sinpe-public.php
+++ b/public/class-mojito-sinpe-public.php
@@ -103,5 +103,11 @@ class Mojito_Sinpe_Public {
 			'mojito_sinpe_show_text_after_banks_list',
 			apply_filters( 'mojito_sinpe_show_text_after_banks_list', 'yes' )
 		);
+
+		wp_localize_script(
+			$this->plugin_name,
+			'mojito_sinpe_bank_phone_numbers',
+			Mojito_Sinpe_Gateway::get_bank_phone_numbers()
+		);
 	}
 }

--- a/public/js/mojito-sinpe-public.js
+++ b/public/js/mojito-sinpe-public.js
@@ -16,57 +16,18 @@
 			return;
 		}
 
-		var bank_number = '';
-		if ( bank === 'bn' ) {
-			bank_number = '2627';
+		var bank_numbers = window.mojito_sinpe_bank_phone_numbers || {};
+		var bank_number = bank_numbers[bank] || '';
 
-		} else if ( bank === 'bcr' ) {
-			bank_number = '4066';
-
-		} else if ( bank === 'bac' ) {
-			bank_number = '70701212';
-
-		} else if ( bank === 'bct' ) {
-			bank_number = '60400300';
-
-		} else if ( bank === 'caja-de-ande' ) {
-			bank_number = '62229532';
-
-		} else if ( bank === 'coopealianza' ) {
-			bank_number = '62229523';
-		
-		} else if ( bank === 'coopecaja' ) {
-			bank_number = '62229526';
-
-		} else if ( bank === 'coocique' ) {
-			bank_number = '46002905';
-				
-		} else if ( bank === 'coopelecheros' ) {
-			bank_number = '60405957';
-
-		} else if ( bank === 'credecoop' ) {
-			bank_number = '71984256';
-
-		} else if ( bank === 'davivienda' ) {
-			bank_number = '70707474';
-
-		} else if ( bank === 'lafise' ) {
-			bank_number = '9091';
-
-		} else if ( bank === 'mucap' ) {
-			bank_number = '62229525';
-
-		} else if ( bank === 'mutual-alajuela' ) {
-			bank_number = '60575079';
-
-		} else if ( bank === 'promerica' ) {
-			bank_number = '62232450';
-
+		if ( bank_number === '' ) {
+			link.hide();
+			text_container.hide();
+			return;
 		}
 
 		if ( mojito_sinpe_show_text_after_banks_list === 'yes' ) {
 			if ( type === 'mobile' ){
-				var href = 'sms:+' + bank_number + '?&body=' + link.data('msj');
+				var href = 'sms:+' + encodeURIComponent( bank_number ) + '?&body=' + encodeURIComponent( link.data('msj') );
 				link.attr('href', href);
 				link.show();
 	

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: quantumdev
 Donate link: https://github.com/sponsors/nomanualdev
 Tags: ecommerce, woocommerce, payment
-Requires at least: 4.6
-Tested up to: 6.7.1
-Stable tag: 1.2.0
+Requires at least: 7.0
+Tested up to: 7.0
+Stable tag: 1.3.0
 Requires PHP: 8.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -36,6 +36,7 @@ The store owner should only add their phone number in "Woocommerce > Settings > 
 
 Add your phone number.
 The client select his bank.
+Compatible with WooCommerce High-Performance Order Storage and Checkout Blocks.
 
 
 == Installation ==
@@ -61,6 +62,14 @@ e.g.
 ¿Desea colaborar con el mantenimiento de este plugin? https://github.com/mojitowp/sinpe
 
 == Changelog ==
+
+= 1.3.0 =
+* WordPress 7.0 compatibility.
+* WooCommerce 10.8.1 compatibility.
+* Functional WooCommerce Checkout Blocks integration.
+* Store API payment data processing for bank and voucher fields.
+* HPOS-safe order meta handling using WooCommerce CRUD.
+* Centralized SINPE bank phone numbers for classic and block checkout.
 
 = 1.2.0 =
 * PHP 8.X compatibility


### PR DESCRIPTION
- Bump version number to 1.3.0 in main plugin file and language files.
- Update compatibility requirements for WordPress (7.0) and WooCommerce (10.8.1).
- Refactor payment link handling to improve REST API integration.
- Centralize bank phone numbers for better management in both classic and block checkout.
- Enhance error handling and validation for order processing.
- Improve code structure and readability by consolidating settings retrieval.
- Add PHPStan stubs for WooCommerce to improve static analysis.
- Update JavaScript to utilize localized bank phone numbers instead of hardcoded values.
- Ensure compatibility with WooCommerce High-Performance Order Storage (HPOS).
- Add changelog entry for version 1.3.0 detailing new features and improvements.